### PR TITLE
move RCurl to Suggests and use try-error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,9 +25,9 @@ Authors@R: c(
 	person("Emmanuel Chigozie", "Elendu", role="ctb"))
 Depends: R (>= 4.0.0), methods, BiocGenerics (>= 0.37.0),
 	S4Vectors (>= 0.25.12), IRanges (>= 2.13.12)
-Imports: stats, stats4, utils, RCurl, GenomeInfoDbData
+Imports: stats, stats4, utils, GenomeInfoDbData
 Suggests: R.utils, data.table, GenomicRanges, Rsamtools, GenomicAlignments,
-	GenomicFeatures, BSgenome,
+	GenomicFeatures, BSgenome, RCurl,
 	TxDb.Dmelanogaster.UCSC.dm3.ensGene,
 	BSgenome.Scerevisiae.UCSC.sacCer2,
 	BSgenome.Celegans.UCSC.ce2,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -4,8 +4,6 @@ importFrom(utils, data, download.file, read.delim, read.table, read.csv,
 importFrom(stats, setNames, update)
 importFrom(stats4, summary)
 
-importFrom(RCurl, getURL)
-
 import(BiocGenerics)
 import(S4Vectors)
 import(IRanges)  # for CompressedList

--- a/R/Ensembl-utils.R
+++ b/R/Ensembl-utils.R
@@ -122,7 +122,13 @@ get_current_Ensembl_release <- function(division=NA, use.grch37=FALSE)
                                         use.grch37=use.grch37)
     README_url <- paste0(top_url, .ENSEMBL_FTP_RELEASE_PREFIX,
                          current_release, "/README")
-    doc <- try(RCurl::getURL(README_url), silent=TRUE)
+    if (!requireNamespace("RCurl", quietly = TRUE))
+        doc <- try(
+            stop("Install 'RCurl' to connect to Ensembl", call. = FALSE),
+            silent = TRUE
+        )
+    else
+        doc <- try(RCurl::getURL(README_url), silent=TRUE)
     if (inherits(doc, "try-error"))
         current_release <- current_release - 1L
     current_release

--- a/R/Ensembl-utils.R
+++ b/R/Ensembl-utils.R
@@ -123,12 +123,9 @@ get_current_Ensembl_release <- function(division=NA, use.grch37=FALSE)
     README_url <- paste0(top_url, .ENSEMBL_FTP_RELEASE_PREFIX,
                          current_release, "/README")
     if (!requireNamespace("RCurl", quietly = TRUE))
-        doc <- try(
-            stop("Install 'RCurl' to connect to Ensembl", call. = FALSE),
-            silent = TRUE
-        )
-    else
-        doc <- try(RCurl::getURL(README_url), silent=TRUE)
+        stop("Install 'RCurl' to connect to Ensembl")
+
+    doc <- try(RCurl::getURL(README_url), silent=TRUE)
     if (inherits(doc, "try-error"))
         current_release <- current_release - 1L
     current_release

--- a/R/list_ftp_dir.R
+++ b/R/list_ftp_dir.R
@@ -25,7 +25,14 @@
 .getURL2 <- function(url)
 {
     stopifnot(isSingleString(url))
-    doc <- try(getURL(url), silent=TRUE)
+    if (!requireNamespace("RCurl", quietly = TRUE))
+        return(
+            try(
+                stop("Install 'RCurl' to connect to Ensembl", call. = FALSE),
+                silent = TRUE
+            )
+        )
+    doc <- try(RCurl::getURL(url), silent=TRUE)
     if (!inherits(doc, "try-error"))
         return(doc)
     condition <- attr(doc, "condition")

--- a/R/list_ftp_dir.R
+++ b/R/list_ftp_dir.R
@@ -26,12 +26,8 @@
 {
     stopifnot(isSingleString(url))
     if (!requireNamespace("RCurl", quietly = TRUE))
-        return(
-            try(
-                stop("Install 'RCurl' to connect to Ensembl", call. = FALSE),
-                silent = TRUE
-            )
-        )
+        stop("Install 'RCurl' to connect to Ensembl")
+
     doc <- try(RCurl::getURL(url), silent=TRUE)
     if (!inherits(doc, "try-error"))
         return(doc)


### PR DESCRIPTION
Hi Hervé, @hpages 

This may be an intermediate solution but it having `RCurl` in `Suggests` would avoid the errors we are seeing in the WASM binary builds. Perhaps you may also want to use `httr` / `httr2`. 

For reference: https://community-bioc.slack.com/archives/C06GSCYKFK5/p1708460547014199

-Marcel